### PR TITLE
CSRF protection

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
 class ApplicationController < ActionController::Base
   include DeviseTokenAuth::Concerns::SetUserByToken
+  protect_from_forgery with: :null_session
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -59,6 +59,7 @@ module NurseStep
                        request_spec: true
     end
 
+    config.middleware.use ActionDispatch::Flash
     config.api_only = true
   end
 end


### PR DESCRIPTION
# Outline
set up CSRF protection

## Work content
- add ` protect_from_forgery with: :null_session` in application_controller
- fix NoMethodError that occurs when rails API is hit