### PR TITLE
Add authenticate method to users controller

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::UsersController < Api::V1::ApiController
   before_action :authenticate_user!, only: [:currentuser]
+  before_action :authenticate_admin!, only: [:index]
 
   def index
     users = User.all

--- a/front/src/reducks/users/operations.ts
+++ b/front/src/reducks/users/operations.ts
@@ -7,18 +7,29 @@ import { User } from "../../types/entity/user";
 
 export const fetchUsers = () => {
   return async (dispatch: Dispatch) => {
-    const apiEndpoint = process.env.REACT_APP_API_URL + "users";
-    
-    axios
-      .get(apiEndpoint)
-      .then((resp) => {
-        dispatch(fetchUsersAction(resp.data));
-      })
-      .catch(() => {
-        setTimeout(() => {
-          dispatch(setNotificationAction({ variant: "error", message: "ユーザー一覧の取得に失敗しました。" }));
-        }, 400);
-      });
+    if (localStorage.getItem("access-token")) {
+      const auth_token = localStorage.getItem("access-token") || "";
+      const client = localStorage.getItem("client") || "";
+      const uid = localStorage.getItem("uid") || "";
+      const apiEndpoint = process.env.REACT_APP_API_URL + "users";
+
+      axios
+        .get(apiEndpoint, {
+          headers: {
+            "access-token": auth_token,
+            client: client,
+            uid: uid,
+          },
+        })
+        .then((resp) => {
+          dispatch(fetchUsersAction(resp.data));
+        })
+        .catch(() => {
+          setTimeout(() => {
+            dispatch(setNotificationAction({ variant: "error", message: "ユーザー一覧の取得に失敗しました。" }));
+          }, 400);
+        });
+    }
   };
 };
 

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -17,11 +17,14 @@ RSpec.describe "Api::V1::Users", type: :request do
   end
 
   describe "GET /api/v1/users" do
-    subject { get(api_v1_users_path) }
+    subject { get(api_v1_users_path, headers: headers) }
 
     before do
       create_list(:user, 8)
     end
+
+    let(:current_admin) { create(:admin) }
+    let(:headers) { current_admin.create_new_auth_token }
 
     it "get list of users" do
       subject


### PR DESCRIPTION
# Overview
Add authenticate method to users controller

# Work contents
- add authenticate_admin! method to before_action in users_controller
- modify fetchUsers method to get information of authentication
- add create_new_auth_token method to test for GET /api/v1/users