### PR TITLE
Enable to fetch commentary in QuizDetail component

### DIFF
--- a/app/controllers/api/v1/commentaries_controller.rb
+++ b/app/controllers/api/v1/commentaries_controller.rb
@@ -3,8 +3,13 @@ class Api::V1::CommentariesController < Api::V1::ApiController
   before_action :authenticate_admin!, only: [:create, :update, :destroy]
 
   def index
-    commentaries = Commentary.all
-    render json: commentaries
+    if params[:quiz_id]
+      commentary = Commentary.find_by(quiz_id: params[:quiz_id])
+      render json: commentary
+    else
+      commentaries = Commentary.all
+      render json: commentaries
+    end
   end
 
   def show

--- a/front/src/templates/QuizDetail.tsx
+++ b/front/src/templates/QuizDetail.tsx
@@ -50,6 +50,8 @@ const QuizDetail = () => {
   useEffect(() => {
     const quizApiEndpoint = process.env.REACT_APP_API_URL + "quizzes/" + match.params.id;
     const choiceApiEndpoint = process.env.REACT_APP_API_URL + "choices?quiz_id=" + match.params.id;
+    const commentaryApiEndpoint =
+      process.env.REACT_APP_API_URL + "commentaries?quiz_id=" + match.params.id;
     let isMounted = true;
 
     axios.get(quizApiEndpoint).then((resp) => {
@@ -61,6 +63,12 @@ const QuizDetail = () => {
     axios.get(choiceApiEndpoint).then((resp) => {
       if (isMounted) {
         setChoices(resp.data);
+      }
+    });
+
+    axios.get(commentaryApiEndpoint).then((resp) => {
+      if (isMounted) {
+        setCommentary(resp.data.text);
       }
     });
 

--- a/spec/requests/api/v1/commentaries_spec.rb
+++ b/spec/requests/api/v1/commentaries_spec.rb
@@ -49,6 +49,22 @@ RSpec.describe "Api::V1::Commentaries", type: :request do
     end
   end
 
+  describe "GET /api/v1/commentaries?quiz_id=number" do
+    subject { get(api_v1_commentaries_path, params: { quiz_id: quiz_id }) }
+
+    let(:quiz_id) { quiz.id }
+    let(:quiz) { create(:quiz) }
+    let!(:commentary) { create(:commentary, quiz_id: quiz_id) }
+
+    it "get commentary which is related to quiz_id" do
+      subject
+      res = JSON.parse(response.body)
+      expect(res.keys).to eq ["id", "text", "quiz_id", "created_at", "updated_at"]
+      expect(res["quiz_id"]).to eq quiz_id
+      expect(response).to have_http_status(200)
+    end
+  end
+
   describe "GET api/v1/commentaries/:id" do
     subject { get(api_v1_commentary_path(commentary_id)) }
 


### PR DESCRIPTION
# Overview
Enable to fetch commentary in QuizDetail component

## Work contents
- update index action in quizzzes_controller to use query string
- enable to fetch commentary in QuizDetail component
- create test for GET /api/v1/commentaries?quiz_id=number