### PR TITLE
Modify method to get quizzes

### DIFF
--- a/app/controllers/api/v1/quizzes_controller.rb
+++ b/app/controllers/api/v1/quizzes_controller.rb
@@ -49,8 +49,8 @@ class Api::V1::QuizzesController < Api::V1::ApiController
   end
 
   def exam_index
-    from = params[:id].to_i - 1
-    to = params[:id].to_i + 5
+    from = params[:exam_id].to_i - 1
+    to = params[:exam_id].to_i + 5
     quizzes = Quiz.all[from..to]
     render json: quizzes
   end

--- a/app/controllers/api/v1/quizzes_controller.rb
+++ b/app/controllers/api/v1/quizzes_controller.rb
@@ -48,6 +48,13 @@ class Api::V1::QuizzesController < Api::V1::ApiController
     render json: @quiz
   end
 
+  def exam_index
+    from = params[:id].to_i - 1
+    to = params[:id].to_i + 5
+    quizzes = Quiz.all[from..to]
+    render json: quizzes
+  end
+
   private
 
     def set_quiz

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
       resources :choices
       resources :commentaries
       post "inquiries/create"
-      get "quizzes/exam/:id", to: "quizzes#exam_index", as: "exam_quizzes"
+      get "quizzes/exam/:exam_id", to: "quizzes#exam_index", as: "exam_quizzes"
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
       resources :choices
       resources :commentaries
       post "inquiries/create"
+      get "quizzes/exam/:id", to: "quizzes#exam_index", as: "exam_quizzes"
     end
   end
 

--- a/front/src/templates/Study.tsx
+++ b/front/src/templates/Study.tsx
@@ -225,9 +225,10 @@ const Study = () => {
   };
 
   useEffect(() => {
-    const quizApiEndpoint = process.env.REACT_APP_API_URL + "quizzes/";
+    // [Need modify!!]: enable dynamic parameter below to be gotten when selecting course
+    const quizApiEndpoint = process.env.REACT_APP_API_URL + "quizzes/exam/1";
     axios.get(quizApiEndpoint).then((resp) => {
-      const newQuizzes = resp.data.slice(0, 7).map((newQuiz: Quiz) => ({
+      const newQuizzes = resp.data.map((newQuiz: Quiz) => ({
         id: newQuiz.id,
         title: newQuiz.title,
         checked: false,

--- a/front/src/templates/Study.tsx
+++ b/front/src/templates/Study.tsx
@@ -143,6 +143,7 @@ type Choice = {
 };
 
 type QuizType = {
+  id: number;
   title: string;
   checked: boolean;
   count: number;
@@ -227,6 +228,7 @@ const Study = () => {
     const quizApiEndpoint = process.env.REACT_APP_API_URL + "quizzes/";
     axios.get(quizApiEndpoint).then((resp) => {
       const newQuizzes = resp.data.slice(0, 7).map((newQuiz: Quiz) => ({
+        id: newQuiz.id,
         title: newQuiz.title,
         checked: false,
         count: 1,

--- a/spec/requests/api/v1/quizzes_spec.rb
+++ b/spec/requests/api/v1/quizzes_spec.rb
@@ -179,4 +179,22 @@ RSpec.describe "Api::V1::Quizzes", type: :request do
       expect(response).to have_http_status(200)
     end
   end
+
+  describe "GET /api/v1/quizzes/exam/:id" do
+    subject { get(api_v1_exam_quizzes_path(exam_id)) }
+
+    before do
+      create_list(:quiz, 10)
+    end
+
+    let(:exam_id) { 1 }
+
+    it "gets seven quizzes" do
+      subject
+      res = JSON.parse(response.body)
+      expect(res.length).to eq 7
+      expect(res[0].keys).to eq ["id", "title", "created_at", "updated_at"]
+      expect(response).to have_http_status(200)
+    end
+  end
 end


### PR DESCRIPTION
# Overview
Modify method to get quizzes

## Work contents
- enable to get seven quizzes
- update routing
- create request spec for GET /api/v1/quizzes/exam/:id
- fix endpoint to get quizzes in Study.tsx
- change dynamic parameter name from ":id" to ":exam_id"