### PR TITLE
Preserve image of category_profile in s3

### DIFF
--- a/app/controllers/api/v1/categories_controller.rb
+++ b/app/controllers/api/v1/categories_controller.rb
@@ -18,10 +18,10 @@ class Api::V1::CategoriesController < Api::V1::ApiController
   end
 
   def create
-    if params[:category_profile]
+    if params[:title] && params[:caption] && params[:image] && params[:uid]
       ActiveRecord::Base.transaction do
         category = Category.create!(category_params)
-        category_profile = category.create_with_category_profile(params[:category_profile])
+        category_profile = category.create_with_category_profile(params[:title], params[:caption], params[:image], params[:uid])
         render json: { category: category, category_profile: category_profile }
       end
     else
@@ -48,6 +48,6 @@ class Api::V1::CategoriesController < Api::V1::ApiController
     end
 
     def category_params
-      params.require(:category).permit(:name).merge(quiz_ids: params[:quiz_ids])
+      params.permit(:name).merge(quiz_ids: params[:quiz_ids])
     end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -5,8 +5,9 @@ class Category < ApplicationRecord
   validates :name, presence: true
   validates :name, uniqueness: true
 
-  def create_with_category_profile(profile)
-    category_profile = self.create_category_profile!(profile.permit!)
+  def create_with_category_profile(title, caption, image, uid)
+    profile_items = { title: title, caption: caption, image: image, uid: uid }
+    category_profile = self.create_category_profile!(profile_items)
     category_profile.save!
   end
 end

--- a/app/models/category_profile.rb
+++ b/app/models/category_profile.rb
@@ -6,4 +6,5 @@ class CategoryProfile < ApplicationRecord
   validates :uid, presence: true
   validates :title, uniqueness: true
   validates :uid, uniqueness: true
+  mount_uploader :image, ImageUploader
 end

--- a/front/src/function/category.ts
+++ b/front/src/function/category.ts
@@ -15,15 +15,24 @@ export const createCategory = (category: string, caption?: string, image?: File 
       const auth_token = localStorage.getItem("access-token") || "";
       const client = localStorage.getItem("client") || "";
       const userId = localStorage.getItem("uid") || "";
-      const headers = { "access-token": auth_token, client: client, uid: userId };
       const apiEndpoint = process.env.REACT_APP_API_URL + "categories";
-      const body: Body = { category: { name: category } };
-      if (caption && image && uid) {
-        body.category_profile = { title: category, caption: caption, image: image, uid: uid };
-      }
+
+      let form: any = new FormData();
+      form.append("name", category);
+      form.append("title", category);
+      form.append("caption", caption);
+      form.append("image", image);
+      form.append("uid", uid);
 
       axios
-        .post(apiEndpoint, body, { headers: headers })
+        .post(apiEndpoint, form, {
+          headers: {
+            "content-type": "multipart/form-data",
+            "access-token": auth_token,
+            client: client,
+            uid: userId,
+          },
+        })
         .then(() => {
           dispatch(showLoadingAction("Create category..."));
           dispatch(push("/category/create"));

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,5 +1,12 @@
 FactoryBot.define do
   factory :category do
     sequence(:name) {|n| "#{n}_#{Faker::Lorem.word}" }
+
+    trait :with_category_profile do
+      title { Faker::Lorem.word }
+      image { Rack::Test::UploadedFile.new Rails.root.join "front/src/assets/img/cat.png" }
+      caption { Faker::Lorem.sentence }
+      uid { Faker::Lorem.word }
+    end
   end
 end

--- a/spec/factories/category_profiles.rb
+++ b/spec/factories/category_profiles.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :category_profile do
     title { Faker::Lorem.word }
-    image { Faker::Avatar.image }
+    image { Rack::Test::UploadedFile.new Rails.root.join "front/src/assets/img/cat.png" }
     caption { Faker::Lorem.sentence }
     uid { Faker::Lorem.word }
     category

--- a/spec/requests/api/v1/categories_spec.rb
+++ b/spec/requests/api/v1/categories_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Api::V1::Categories", type: :request do
     subject { post(api_v1_categories_path, params: params, headers: headers) }
 
     context "send correct category information" do
-      let(:params) { { category: attributes_for(:category), quiz_ids: quiz_ids } }
+      let(:params) { attributes_for(:category, quiz_ids: quiz_ids) }
       let(:current_admin) { create(:admin) }
       let(:headers) { current_admin.create_new_auth_token }
       let!(:quiz_ids) { quiz.id }
@@ -19,7 +19,7 @@ RSpec.describe "Api::V1::Categories", type: :request do
     end
 
     context "send correct category information with category_profile" do
-      let(:params) { { category: attributes_for(:category), quiz_ids: quiz_ids, category_profile: attributes_for(:category_profile) } }
+      let(:params) { attributes_for(:category, :with_category_profile, quiz_ids: quiz_ids) }
       let(:current_admin) { create(:admin) }
       let(:headers) { current_admin.create_new_auth_token }
       let!(:quiz_ids) { quiz.id }
@@ -34,7 +34,7 @@ RSpec.describe "Api::V1::Categories", type: :request do
     end
 
     context "send correct category information without quiz_ids" do
-      let(:params) { { category: attributes_for(:category) } }
+      let(:params) { attributes_for(:category) }
       let(:current_admin) { create(:admin) }
       let(:headers) { current_admin.create_new_auth_token }
 
@@ -110,12 +110,12 @@ RSpec.describe "Api::V1::Categories", type: :request do
 
     let(:headers) { current_admin.create_new_auth_token }
     let(:current_admin) { create(:admin) }
-    let(:params) { { category: { name: Faker::Lorem.word, created_at: Time.current } } }
+    let(:params) { { name: Faker::Lorem.word, created_at: Time.current } }
     let(:category_id) { category.id }
     let(:category) { create(:category) }
 
     it "category is updated" do
-      expect { subject }.to change { category.reload.name }.from(category.name).to(params[:category][:name]) &
+      expect { subject }.to change { category.reload.name }.from(category.name).to(params[:name]) &
                             not_change { category.reload.created_at }
       expect(response).to have_http_status(200)
     end

--- a/spec/requests/api/v1/category_profiles_spec.rb
+++ b/spec/requests/api/v1/category_profiles_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "Api::V1::CategoryProfiles", type: :request do
         res = JSON.parse(response.body)
         expect(res["id"]).to eq category_profile.id
         expect(res["title"]).to eq category_profile.title
-        expect(res["image"]).to eq category_profile.image
+        expect(res["image"]["url"]).to eq category_profile.image.url
         expect(res["caption"]).to eq category_profile.caption
         expect(res["uid"]).to eq category_profile.uid
         expect(response).to have_http_status(200)
@@ -74,13 +74,12 @@ RSpec.describe "Api::V1::CategoryProfiles", type: :request do
 
     let(:headers) { current_admin.create_new_auth_token }
     let(:current_admin) { create(:admin) }
-    let(:params) { { category_profile: { title: Faker::Lorem.word, image: Faker::Avatar.image, created_at: Time.current } } }
+    let(:params) { { category_profile: { title: Faker::Lorem.word, created_at: Time.current } } }
     let(:category_profile_id) { category_profile.id }
     let(:category_profile) { create(:category_profile) }
 
     it "category_profile is updated" do
       expect { subject }.to change { category_profile.reload.title }.from(category_profile.title).to(params[:category_profile][:title]) &
-                            change { category_profile.reload.image }.from(category_profile.image).to(params[:category_profile][:image]) &
                             not_change { category_profile.reload.created_at }
       expect(response).to have_http_status(200)
     end


### PR DESCRIPTION
# Overview
Preserve image of category_profile in s3

## Work contents
- mount uploader on category_profile
- modify instance method to get more arguments
- modify crate action for category
- enable to  pass arguments as form data
- fix factories about category_profile
- enable factory about category to use trait for creating category_profile
- fix request spec