### PR TITLE
Add level and experience_point columns

### DIFF
--- a/db/migrate/20220227081044_add_column_to_user.rb
+++ b/db/migrate/20220227081044_add_column_to_user.rb
@@ -1,0 +1,6 @@
+class AddColumnToUser < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :level, :integer
+    add_column :users, :experience_point, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_14_215743) do
+ActiveRecord::Schema.define(version: 2022_02_27_081044) do
 
   create_table "admins", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "provider", default: "email", null: false
@@ -119,6 +119,8 @@ ActiveRecord::Schema.define(version: 2022_02_14_215743) do
     t.text "tokens"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "level"
+    t.integer "experience_point"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Api::V1::Users", type: :request do
       subject
       res = JSON.parse(response.body)
       expect(res.length).to eq 8
-      expect(res[0].keys).to eq ["id", "provider", "uid", "allow_password_change", "name", "nickname", "image", "email", "created_at", "updated_at"]
+      expect(res[0].keys).to eq ["id", "provider", "uid", "allow_password_change", "name", "nickname", "image", "email", "created_at", "updated_at", "level", "experience_point"]
       expect(response).to have_http_status(200)
     end
   end
@@ -46,7 +46,7 @@ RSpec.describe "Api::V1::Users", type: :request do
     it "get detail of user" do
       subject
       res = JSON.parse(response.body)
-      expect(res.keys).to eq ["id", "provider", "uid", "allow_password_change", "name", "nickname", "image", "email", "created_at", "updated_at"]
+      expect(res.keys).to eq ["id", "provider", "uid", "allow_password_change", "name", "nickname", "image", "email", "created_at", "updated_at", "level", "experience_point"]
       expect(response).to have_http_status(200)
     end
   end


### PR DESCRIPTION
# Overview
Add level and experience_point columns

## Work contents
- add level and experience_point columns to user model
- rails db:migrate
- fix users_spec regarding to new columns